### PR TITLE
Fix bootstrapping problem.

### DIFF
--- a/ddsc_core/models/alarms.py
+++ b/ddsc_core/models/alarms.py
@@ -55,7 +55,7 @@ class Alarm(BaseModel):
     single_or_group = models.ForeignKey(
         ContentType,
         limit_choices_to={"model__in": ("user", "usergroup")},
-        default=ContentType.objects.get_for_model(User).pk,
+        default=lambda: ContentType.objects.get_for_model(User).pk,
     )
     description = models.TextField(
         null=True,


### PR DESCRIPTION
When starting from scratch, the `bin/django syncdb/migrate` sequence runs into a bootstrapping problem, because there is no django_content_type table yet. This pull request fixes the problem.
